### PR TITLE
Update Conversion controller docs

### DIFF
--- a/lib/docspec/api/controller/conversion.ex
+++ b/lib/docspec/api/controller/conversion.ex
@@ -1,6 +1,6 @@
 defmodule DocSpec.API.Controller.Conversion do
   @moduledoc """
-  Router for validation API.
+  Router for conversion API.
   """
 
   use Plug.Builder


### PR DESCRIPTION
## Summary
- clarify that `DocSpec.API.Controller.Conversion` routes the conversion API

## Testing
- `mix test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f27adf648321bc2a58107007bc16