### PR TITLE
Fix typed struct children type

### DIFF
--- a/lib/blocknote/spec/bullet_list_item.ex
+++ b/lib/blocknote/spec/bullet_list_item.ex
@@ -11,6 +11,6 @@ defmodule BlockNote.Spec.BulletListItem do
     field :id, String.t()
     field :type, :bulletListItem, default: :bulletListItem
     field :content, content(), default: []
-    field :children, [__MODULE__.t() | BlockNote.Spec.NumberedListItem], default: []
+    field :children, [__MODULE__.t() | BlockNote.Spec.NumberedListItem.t()], default: []
   end
 end


### PR DESCRIPTION
## Summary
- fix incorrect type spec in `BulletListItem`'s children field

## Testing
- `mix test` *(fails: Could not find an SCM for dependency :nldoc_spec)*

------
https://chatgpt.com/codex/tasks/task_e_6841f178da84832198246c9665534bed