### PR TITLE
Fix typo in PutRespHeader docs

### DIFF
--- a/lib/docspec/api/plug/put_resp_header.ex
+++ b/lib/docspec/api/plug/put_resp_header.ex
@@ -1,6 +1,6 @@
 defmodule DocSpec.API.Plug.PutRespHeader do
   @moduledoc """
-  This module provides a Plug that puts a specific header on all respones.
+  This module provides a Plug that puts a specific header on all responses.
   """
   @behaviour Plug
 


### PR DESCRIPTION
## Summary
- fix a typo in `DocSpec.API.Plug.PutRespHeader` docs

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f3323d748321872d9be3922413c6