### PR TITLE
Add basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: '1.18'
+          otp-version: '26'
+      - name: Install dependencies
+        run: mix deps.get
+      - name: Check code format
+        run: mix format --check-formatted
+      - name: Run tests
+        run: mix test
+      - name: Run Dialyzer
+        run: mix dialyzer --format github


### PR DESCRIPTION
## Summary
- add a new GitHub Actions workflow to run mix format, mix test and dialyzer

## Testing
- `mix test` *(fails: Could not install Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6841f1a6fbbc8321b5fad1be0de60f86