### PR TITLE
Fix BlockNote content types

### DIFF
--- a/lib/blocknote/spec/bullet_list_item.ex
+++ b/lib/blocknote/spec/bullet_list_item.ex
@@ -5,7 +5,7 @@ defmodule BlockNote.Spec.BulletListItem do
 
   use TypedStruct
 
-  @type content() :: BlockNote.Spec.Text.t()
+  @type content() :: [BlockNote.Spec.Text.t()]
 
   typedstruct enforce: true do
     field :id, String.t()

--- a/lib/blocknote/spec/document.ex
+++ b/lib/blocknote/spec/document.ex
@@ -5,7 +5,7 @@ defmodule BlockNote.Spec.Document do
 
   use TypedStruct
 
-  @type content() :: BlockNote.Spec.Paragraph.t() | BlockNote.Spec.Heading.t()
+  @type content() :: [BlockNote.Spec.Paragraph.t() | BlockNote.Spec.Heading.t()]
 
   typedstruct enforce: true do
     field :id, String.t()

--- a/lib/blocknote/spec/heading.ex
+++ b/lib/blocknote/spec/heading.ex
@@ -7,7 +7,7 @@ defmodule BlockNote.Spec.Heading do
 
   alias BlockNote.Spec.Heading.Props
 
-  @type content() :: BlockNote.Spec.Text.t()
+  @type content() :: [BlockNote.Spec.Text.t()]
 
   typedstruct enforce: true do
     field :id, String.t()

--- a/lib/blocknote/spec/numbered_list_item.ex
+++ b/lib/blocknote/spec/numbered_list_item.ex
@@ -5,7 +5,7 @@ defmodule BlockNote.Spec.NumberedListItem do
 
   use TypedStruct
 
-  @type content() :: BlockNote.Spec.Text.t()
+  @type content() :: [BlockNote.Spec.Text.t()]
 
   typedstruct enforce: true do
     field :id, String.t()

--- a/lib/blocknote/spec/paragraph.ex
+++ b/lib/blocknote/spec/paragraph.ex
@@ -5,7 +5,7 @@ defmodule BlockNote.Spec.Paragraph do
 
   use TypedStruct
 
-  @type content() :: BlockNote.Spec.Text.t()
+  @type content() :: [BlockNote.Spec.Text.t()]
 
   typedstruct enforce: true do
     field :id, String.t()

--- a/lib/blocknote/spec/table.ex
+++ b/lib/blocknote/spec/table.ex
@@ -10,6 +10,6 @@ defmodule BlockNote.Spec.Table do
   typedstruct enforce: true do
     field :id, String.t()
     field :type, :table, default: :table
-    field :content, content(), default: []
+    field :content, content(), default: %BlockNote.Spec.Table.Content{}
   end
 end


### PR DESCRIPTION
## Summary
- fix content type for Document and text-based resources to be lists
- use correct default for table content

## Testing
- `mix compile` *(fails: Could not find Hex)*

------
https://chatgpt.com/codex/tasks/task_e_6841f32bdc14832182796c276ee790a8